### PR TITLE
Manually implement the Debug trait for FftError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@ use std::sync::Arc;
 type Res<T> = Result<T, FftError>;
 
 /// Custom error returned by FFTs
-#[derive(Debug)]
 pub enum FftError {
     /// The input buffer has the wrong size. The transform was not performed.
     InputBuffer(usize, usize),
@@ -158,8 +157,8 @@ pub enum FftError {
     InputValues(bool, bool),
 }
 
-impl fmt::Display for FftError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl FftError {
+    fn fmt_internal(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let desc = match self {
             Self::InputBuffer(got, expected) => {
                 format!("Wrong length of input, expected {}, got {}", got, expected)
@@ -183,6 +182,18 @@ impl fmt::Display for FftError {
             },
         };
         write!(f, "{}", desc)
+    }
+}
+
+impl fmt::Debug for FftError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_internal(f)
+    }
+}
+
+impl fmt::Display for FftError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_internal(f)
     }
 }
 


### PR DESCRIPTION
The trait that get's used to display the error message when an
`unwrap()` is called on an `Error` is the Debug traits implementation.
It's much easier to understand the error when the explanation is written
out rather than trying to figure out what the Error variant tuple
members represents.

This changes the Debug trait's behaviour to match that of the Display
trait. I'm unsure why the Error trait requires the implementing type to
be Display as well as Debug. My understanding is that it's a message
supposed to help the end-user rather than the developer. The same
message would be appropriate for both cases AFAICT.