### PR TITLE
Fix variable naming in FftError Display impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,16 +161,16 @@ pub enum FftError {
 impl fmt::Display for FftError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let desc = match self {
-            Self::InputBuffer(got, expected) => {
-                format!("Wrong length of input, expected {}, got {}", got, expected)
+            Self::InputBuffer(expected, got) => {
+                format!("Wrong length of input, expected {}, got {}", expected, got)
             }
-            Self::OutputBuffer(got, expected) => {
-                format!("Wrong length of output, expected {}, got {}", got, expected)
+            Self::OutputBuffer(expected, got) => {
+                format!("Wrong length of output, expected {}, got {}", expected, got)
             }
-            Self::ScratchBuffer(got, expected) => {
+            Self::ScratchBuffer(expected, got) => {
                 format!(
                     "Wrong length of scratch, expected {}, got {}",
-                    got, expected
+                    expected, got
                 )
             }
             Self::InputValues(first, last) => match (first, last) {


### PR DESCRIPTION
The variable name is misleading and does not represent the correct
interpretation. What likely happened is that the variable matching was
mistakenly swapped.

This change has no effect to the consumer of realfft.