### PR TITLE
Const generics - RFC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rustfft = "6.0.0"
 [dev-dependencies]
 criterion = "0.3"
 rand = "0.8.3"
+trybuild = "1.0.64"
 
 [[bench]]
 name = "realfft"

--- a/compilation_tests/wrong_input_size.rs
+++ b/compilation_tests/wrong_input_size.rs
@@ -1,0 +1,12 @@
+//! Show that compiler does not allow incorrect input fft buffers
+
+use realfft::{num_complex::Complex, RealFftPlanner};
+
+fn main() {
+    let mut planner = RealFftPlanner::<f32>::new();
+    const LENGTH: usize = 100;
+    let r2c = planner.plan_fft_forward::<LENGTH>();
+    let mut input = [0.0; LENGTH - 1];
+    let mut output = [Complex::default(); LENGTH / 2 + 1];
+    r2c.process(&mut input, &mut output).unwrap();
+}

--- a/compilation_tests/wrong_input_size.stderr
+++ b/compilation_tests/wrong_input_size.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+   --> compilation_tests/wrong_input_size.rs:11:17
+    |
+11  |     r2c.process(&mut input, &mut output).unwrap();
+    |         ------- ^^^^^^^^^^ expected an array with a fixed size of 100 elements, found one with 99 elements
+    |         |
+    |         arguments to this function are incorrect
+    |
+note: associated function defined here
+   --> src/lib.rs
+    |
+    |     fn process(
+    |        ^^^^^^^

--- a/compilation_tests/wrong_output_size.rs
+++ b/compilation_tests/wrong_output_size.rs
@@ -1,0 +1,12 @@
+//! Show that compiler does not allow incorrect output fft buffers
+
+use realfft::{num_complex::Complex, RealFftPlanner};
+
+fn main() {
+    let mut planner = RealFftPlanner::<f32>::new();
+    const LENGTH: usize = 100;
+    let r2c = planner.plan_fft_forward::<LENGTH>();
+    let mut input = [0.0; LENGTH];
+    let mut output = [Complex::default(); LENGTH / 2];
+    r2c.process(&mut input, &mut output).unwrap();
+}

--- a/compilation_tests/wrong_output_size.stderr
+++ b/compilation_tests/wrong_output_size.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+   --> compilation_tests/wrong_output_size.rs:11:29
+    |
+11  |     r2c.process(&mut input, &mut output).unwrap();
+    |         -------             ^^^^^^^^^^^ expected an array with a fixed size of 51 elements, found one with 50 elements
+    |         |
+    |         arguments to this function are incorrect
+    |
+    = note: expected mutable reference `&mut [Complex<f32>; 51]`
+               found mutable reference `&mut [Complex<_>; 50]`
+note: associated function defined here
+   --> src/lib.rs
+    |
+    |     fn process(
+    |        ^^^^^^^

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -14,8 +14,8 @@ fn main() {
         .map(|_| {
             let fft_copy = Arc::clone(&fft);
             thread::spawn(move || {
-                let mut data = fft_copy.make_input_vec();
-                let mut output = fft_copy.make_output_vec();
+                let mut data = fft_copy.make_input();
+                let mut output = fft_copy.make_output();
                 fft_copy.process(&mut data, &mut output).unwrap();
             })
         })

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -8,7 +8,7 @@ use realfft::RealFftPlanner;
 fn main() {
     let mut planner = RealFftPlanner::<f32>::new();
     const LENGTH: usize = 100;
-    let fft = planner.plan_fft_forward::<LENGTH>(LENGTH);
+    let fft = planner.plan_fft_forward::<LENGTH>();
 
     let threads: Vec<thread::JoinHandle<_>> = (0..2)
         .map(|_| {

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -7,7 +7,8 @@ use realfft::RealFftPlanner;
 
 fn main() {
     let mut planner = RealFftPlanner::<f32>::new();
-    let fft = planner.plan_fft_forward(100);
+    const LENGTH: usize = 100;
+    let fft = planner.plan_fft_forward::<LENGTH>(LENGTH);
 
     let threads: Vec<thread::JoinHandle<_>> = (0..2)
         .map(|_| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1089,4 +1089,10 @@ mod tests {
         r2c.process(&mut indata, &mut out_a)?;
         Ok(())
     }
+
+    #[test]
+    fn compiler_does_not_allow_incorrect_buffer_sizes() {
+        let test_case = trybuild::TestCases::new();
+        test_case.compile_fail("compilation_tests/*.rs");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,8 +267,8 @@ pub trait RealToComplex<T, const FFT_SIZE: usize>: Sync + Send {
     /// An error is returned if any of the given slices has the wrong length.
     fn process_with_scratch(
         &self,
-        input: &mut [T],
-        output: &mut [Complex<T>],
+        input: &mut [T; FFT_SIZE],
+        output: &mut [Complex<T>; FFT_SIZE / 2 + 1],
         scratch: &mut [Complex<T>],
     ) -> Res<()>;
 
@@ -422,8 +422,8 @@ impl<T: FftNum, const FFT_SIZE: usize> RealToComplex<T, FFT_SIZE>
     /// An error is returned if any of the given slices has the wrong length.
     fn process_with_scratch(
         &self,
-        input: &mut [T],
-        output: &mut [Complex<T>],
+        input: &mut [T; FFT_SIZE],
+        output: &mut [Complex<T>; FFT_SIZE / 2 + 1],
         scratch: &mut [Complex<T>],
     ) -> Res<()> {
         if input.len() != FFT_SIZE {
@@ -519,8 +519,8 @@ impl<T: FftNum, const FFT_SIZE: usize> RealToComplex<T, FFT_SIZE>
     /// An error is returned if any of the given slices has the wrong length.
     fn process_with_scratch(
         &self,
-        input: &mut [T],
-        output: &mut [Complex<T>],
+        input: &mut [T; FFT_SIZE],
+        output: &mut [Complex<T>; FFT_SIZE / 2 + 1],
         scratch: &mut [Complex<T>],
     ) -> Res<()> {
         if input.len() != FFT_SIZE {
@@ -547,7 +547,7 @@ impl<T: FftNum, const FFT_SIZE: usize> RealToComplex<T, FFT_SIZE>
         // FFT and store result in buffer_out
         self.fft
             .process_outofplace_with_scratch(buf_in, &mut output[0..fftlen], scratch);
-        let (mut output_left, mut output_right) = output.split_at_mut(output.len() / 2);
+        let (mut output_left, mut output_right) = output.split_at_mut((FFT_SIZE / 2 + 1) / 2);
 
         // The first and last element don't require any twiddle factors, so skip that work
         match (output_left.first_mut(), output_right.last_mut()) {
@@ -609,7 +609,7 @@ impl<T: FftNum, const FFT_SIZE: usize> RealToComplex<T, FFT_SIZE>
 
         // If the output len is odd, the loop above can't postprocess the centermost element, so handle that separately.
         if output.len() % 2 == 1 {
-            if let Some(center_element) = output.get_mut(output.len() / 2) {
+            if let Some(center_element) = output.get_mut((FFT_SIZE / 2 + 1) / 2) {
                 center_element.im = -center_element.im;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 //! let mut real_planner = RealFftPlanner::<f64>::new();
 //!
 //! // create a FFT
-//! let r2c = real_planner.plan_fft_forward::<LENGTH>(LENGTH);
+//! let r2c = real_planner.plan_fft_forward::<LENGTH>();
 //! // make input and output vectors
 //! let mut indata = r2c.make_input();
 //! let mut spectrum = r2c.make_output();
@@ -359,9 +359,8 @@ impl<T: FftNum> RealFftPlanner<T> {
     /// If requesting a second FFT of the same length, this will return a new reference to the already existing one.
     pub fn plan_fft_forward<const FFT_SIZE: usize>(
         &mut self,
-        len: usize,
     ) -> Arc<dyn RealToComplex<T, FFT_SIZE>> {
-        if len % 2 > 0 {
+        if FFT_SIZE % 2 > 0 {
             Arc::new(RealToComplexOdd::new(&mut self.planner))
                 as Arc<dyn RealToComplex<T, FFT_SIZE>>
         } else {
@@ -1055,7 +1054,7 @@ mod tests {
     fn real_to_complex() {
         const LENGTH: usize = 1000;
         let mut real_planner = RealFftPlanner::<f64>::new();
-        let r2c = real_planner.plan_fft_forward::<LENGTH>(LENGTH);
+        let r2c = real_planner.plan_fft_forward::<LENGTH>();
         let mut out_a = r2c.make_output();
         let mut indata = r2c.make_input();
         let mut rng = rand::thread_rng();
@@ -1084,7 +1083,7 @@ mod tests {
     #[allow(dead_code)]
     fn test_error() -> Result<(), Box<dyn Error>> {
         let mut real_planner = RealFftPlanner::<f64>::new();
-        let r2c = real_planner.plan_fft_forward::<100>(100);
+        let r2c = real_planner.plan_fft_forward::<100>();
         let mut out_a = r2c.make_output();
         let mut indata = r2c.make_input();
         r2c.process(&mut indata, &mut out_a)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,16 +426,7 @@ impl<T: FftNum, const FFT_SIZE: usize> RealToComplex<T, FFT_SIZE>
         output: &mut [Complex<T>; FFT_SIZE / 2 + 1],
         scratch: &mut [Complex<T>],
     ) -> Res<()> {
-        if input.len() != FFT_SIZE {
-            return Err(FftError::InputBuffer(FFT_SIZE, input.len()));
-        }
-        let expected_output_buffer_size = FFT_SIZE / 2 + 1;
-        if output.len() != expected_output_buffer_size {
-            return Err(FftError::OutputBuffer(
-                expected_output_buffer_size,
-                output.len(),
-            ));
-        }
+        // Compiler now checks that input and output are the correct sizes
         if scratch.len() != (self.scratch_len) {
             return Err(FftError::ScratchBuffer(FFT_SIZE, scratch.len()));
         }
@@ -523,16 +514,7 @@ impl<T: FftNum, const FFT_SIZE: usize> RealToComplex<T, FFT_SIZE>
         output: &mut [Complex<T>; FFT_SIZE / 2 + 1],
         scratch: &mut [Complex<T>],
     ) -> Res<()> {
-        if input.len() != FFT_SIZE {
-            return Err(FftError::InputBuffer(FFT_SIZE, input.len()));
-        }
-        let expected_output_buffer_size = FFT_SIZE / 2 + 1;
-        if output.len() != expected_output_buffer_size {
-            return Err(FftError::OutputBuffer(
-                expected_output_buffer_size,
-                output.len(),
-            ));
-        }
+        // Compiler now checks that input and output are the correct sizes
         if scratch.len() != (self.scratch_len) {
             return Err(FftError::ScratchBuffer(FFT_SIZE, scratch.len()));
         }


### PR DESCRIPTION
This is just a POC to show how [const generics](https://rust-lang.github.io/rfcs/2000-const-generics.html) can help turn runtime bugs into compile time errors. This PR is not meant to be merged [yet] but only meant to gather comments about the idea. I've only implemented the constification for the `RealToComplex`/`forward_fft` parts to cut down on the size of the POC. There is no reason I can't do the same for the reverse operations. If I did implement these it would then remove the `FftError::InputBuffer` and `FftError::OutputBuffer` variants completely. 

Currently I see the following issues:
1. Requires the user to know the size of the fft at compile-time. Although this is mostly true the case, it is limiting.
2. Does not work with the current caching implementation since the type of the cached items is now generic.
3. The underlying `rustfft` crate is not constified.
4. It requires a major version bump.
5. The [`generic_const_exprs`](https://github.com/rust-lang/rust/issues/76560) is still unstable.
6. Bumps the `rustc` dependency. Probably a version not yet released.

I do have some vague thoughts about the above issues:
1. Expose two separate API's in one crate or create an entirely separate crate. This does come at the const of complexity and confusion which to choose. If it can be shown that runtime chosen fft sizes are never really used then it may be worth it to only expose one const generic API.
2. In the const case caching should not be a problem so the const API/crate won't need it. It should always be possible for the user to pass a reference.
3. I've already opened an issue asking for opinions https://github.com/ejmahler/RustFFT/issues/93. This POC may even be used as motivation. I do think most of the gains along with most of the complexity, lies in the `rustfft` crate.
4. Nothing much we can do about this. Could turn into a minor version bump if we do go the separate API/crate route.
5. We'll just have to wait for [`generic_const_exprs`](https://github.com/rust-lang/rust/issues/76560) to be stabilised. Perhaps we can help in the effort.
6. Relying on modern features is a bit sad, folks who have a dependency on older rust versions can always use older versions of the crate.

My understanding of the advantages are as follow:
1. This turns runtime bugs into compile time errors. THIS IS HUGE. Don't underestimate the advantage this brings.
2. Reduce allocations - notice how `make_input_vec` and `make_output_vec` changed to `make_input` and `make_output` respectively, and returning arrays instead of vectors. I'm sure there are other places I've missed that can remove allocations as well.
3. Help compiler optimise code - My understanding is that const-generics provides the compiler with more info that it can use to optimise code, although I don't know any specifics.
4. Eliminates runtime checks and dispatching