### PR TITLE
Remove unnecessary num_traits re-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Transform a vector, and then inverse transform the result.
 ```rust
 use realfft::RealFftPlanner;
 use rustfft::num_complex::Complex;
-use rustfft::num_traits::Zero;
 
 let length = 256;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,6 @@
 //! ```
 //! use realfft::RealFftPlanner;
 //! use rustfft::num_complex::Complex;
-//! use rustfft::num_traits::Zero;
 //!
 //! let length = 256;
 //!
@@ -131,7 +130,6 @@
 //! The `realfft` crate requires rustc version 1.37 or newer.
 
 pub use rustfft::num_complex;
-pub use rustfft::num_traits;
 pub use rustfft::FftNum;
 
 use rustfft::num_complex::Complex;


### PR DESCRIPTION
Nothing in the external API requires the consumer to use num_traits.

This requires a major version change. See [corresponding PR in rustfft](https://github.com/ejmahler/RustFFT/pull/95) before merging