### PR TITLE
Bump rustfft version to 6.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustfft = "6.0.0"
+rustfft = "6.1.0"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Enabling neon support on stable.