### PR TITLE
Clean up undefined behaviour

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,7 +905,7 @@ impl<T: FftNum> ComplexToReal<T> for ComplexToRealEven<T> {
             std::slice::from_raw_parts_mut(ptr, len / 2)
         };
         self.fft
-            .process_outofplace_with_scratch(&mut input[..output.len() / 2], buf_out, scratch);
+            .process_outofplace_with_scratch(&mut input[..buf_out.len()], buf_out, scratch);
         if first_invalid || last_invalid {
             return Err(FftError::InputValues(first_invalid, last_invalid));
         }


### PR DESCRIPTION
This pr closes #32 

The issue is is that `output` is borrowed exclusively here:
https://github.com/HEnquist/realfft/blob/ed26ea38de34ce029f518beeccd7b83439016466/src/lib.rs#L902-L906
But is then used again in the expression `output.len() / 2` while it is still borrowed:
https://github.com/HEnquist/realfft/blob/ed26ea38de34ce029f518beeccd7b83439016466/src/lib.rs#L907-L908