### PR TITLE
Provide same features as RustFFT, mapping to them one-to-one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,17 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Map RealFFT's features one-to-one with RustFFT's. For more information, refer
+# to the Feature Flags section at https://docs.rs/rustfft/latest/rustfft/
+default = ["rustfft/default"]
+avx = ["rustfft/avx"]
+sse = ["rustfft/sse"]
+neon = ["rustfft/neon"]
+wasm_simd = ["rustfft/wasm_simd"]
+
 [dependencies]
-rustfft = "6.2.0"
+rustfft = { version = "6.2.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 This library is a wrapper for [RustFFT](https://crates.io/crates/rustfft)
 that enables fast and convenient FFT of real-valued data.
-The API is designed to be as similar as possible to RustFFT.
+The API is designed to be as similar as possible to RustFFT. Also, the feature flags are passed
+on to RustFFT, allowing selection of its features – they do not affect RealFFT itself.
 
 Using this library instead of RustFFT directly avoids the need of converting
 real-valued data to complex before performing a FFT.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! This library is a wrapper for [RustFFT](https://crates.io/crates/rustfft)
 //! that enables fast and convenient FFT of real-valued data.
-//! The API is designed to be as similar as possible to RustFFT.
+//! The API is designed to be as similar as possible to RustFFT. Also, the feature flags are passed
+//! on to RustFFT, allowing selection of its features – they do not affect RealFFT itself.
 //!
 //! Using this library instead of RustFFT directly avoids the need of converting
 //! real-valued data to complex before performing a FFT.


### PR DESCRIPTION
I noticed that in projects depending separately on both RealFFT and RustFFT, the default features of RustFFT get selected even when configuring that dependency with `default-features = false` and `features = ["avx"]`.

This PR adds the [features available in RustFFT](https://docs.rs/rustfft/latest/rustfft/#feature-flags) to RealFFT as well, enabling the corresponding RustFFT features only when selected. RealFFT's `default` feature enables RustFFT's `default` feature, so existing use cases shouldn't be affected.